### PR TITLE
Regression test for setExtChrg and another fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,11 @@ Fixed
 
 - Memory leak for MPI enabled code with many geometric steps.
 
+- API call to setExternalCharges was not marking calculation to be
+  re-evaluated.
+
+- setExternalCharges was failing if number of external charges
+  changes.
 
 23.1 (2023-07-05)
 =================

--- a/src/dftbp/dftbplus/mainapi.F90
+++ b/src/dftbp/dftbplus/mainapi.F90
@@ -465,6 +465,12 @@ contains
       end if
     end if
     call main%scc%setExternalCharges(chargeCoords, chargeQs, blurWidths=blurWidths)
+    ! work around for lack (at the moment) for a flag to re-calculate ground state even if
+    ! geometries are unchanged.
+    main%tCoordsChanged = .true.
+    if (main%tPeriodic) then
+      main%tLatticeChanged = .true.
+    end if
 
   end subroutine setExternalCharges
 


### PR DESCRIPTION
This adds a regression test for your changes, but also fixes another bug I found in the process:
The API now correctly marks the calculation for re-evaluation if the external charges change.